### PR TITLE
fix: type review fields so next build (Amplify) lint passes

### DIFF
--- a/src/app/artiste/(main)/catalog/misc/api/getArtisteAlbums.ts
+++ b/src/app/artiste/(main)/catalog/misc/api/getArtisteAlbums.ts
@@ -26,6 +26,9 @@ export interface TArtisteAlbum {
 	artistName: string;
 	recordLabel: string;
 	publisher: string;
+	writer?: string;
+	reviewStatus?: 'pending' | 'approved' | 'rejected';
+	rejectionReasons?: string[];
 	instruments: string[];
 	explicitContent: string;
 	universalProductCode: string;

--- a/src/app/artiste/(main)/catalog/misc/api/getArtisteMedias.ts
+++ b/src/app/artiste/(main)/catalog/misc/api/getArtisteMedias.ts
@@ -36,6 +36,9 @@ export interface TArtistMedia {
 	mediaUrl: string;
 	recordLabel: string;
 	publisher: string;
+	writer?: string;
+	reviewStatus?: 'pending' | 'approved' | 'rejected';
+	rejectionReasons?: string[];
 	instruments: string[];
 	lyrics: string;
 	explicitContent: string;

--- a/src/app/artiste/(main)/catalog/misc/components/AlbumCard.tsx
+++ b/src/app/artiste/(main)/catalog/misc/components/AlbumCard.tsx
@@ -54,7 +54,7 @@ const AlbumCard = ({ album }: { album: TArtisteAlbum }) => {
 		description: album.description || '',
 		recordLabel: album.recordLabel || '',
 		publisher: album.publisher || '',
-		writer: (album as any).writer || '',
+		writer: album.writer || '',
 		copyright: album.copyright || '',
 		explicitContent: album.explicitContent || 'No',
 		universalProductCode: album.universalProductCode || '',
@@ -151,7 +151,7 @@ const AlbumCard = ({ album }: { album: TArtisteAlbum }) => {
 			</div>
 			<footer className="px-3">
 				<h6>{album.title}</h6>
-				{(album as any).reviewStatus === 'rejected' && (
+				{album.reviewStatus === 'rejected' && (
 					<button type="button" onClick={openEditSheet} className="mt-1 inline-flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-[11px] font-medium text-red-500 hover:bg-red-500/25">
 						Rejected — edit to resubmit
 					</button>
@@ -181,11 +181,11 @@ const AlbumCard = ({ album }: { album: TArtisteAlbum }) => {
 								</div>
 							</div>
 
-							{(album as any).reviewStatus === 'rejected' && Array.isArray((album as any).rejectionReasons) && (album as any).rejectionReasons.length > 0 && (
+							{album.reviewStatus === 'rejected' && Array.isArray(album.rejectionReasons) && album.rejectionReasons.length > 0 && (
 								<div className="mx-4 mb-4 rounded-lg border border-red-500/40 bg-red-500/10 p-3">
 									<p className="text-sm font-semibold text-red-400 mb-1">This release was rejected. Please fix and resubmit:</p>
 									<ul className="list-disc list-inside text-sm text-red-300 space-y-0.5">
-										{(album as any).rejectionReasons.map((r: string, i: number) => (
+										{album.rejectionReasons.map((r: string, i: number) => (
 											<li key={i}>{r}</li>
 										))}
 									</ul>
@@ -390,7 +390,7 @@ const AlbumCard = ({ album }: { album: TArtisteAlbum }) => {
 													</TooltipProvider>
 												</FormLabel>
 												<FormControl>
-													<Input placeholder="Writer's full legal name" hasError={!!(errors as any).writer} errormessage={(errors as any).writer?.message} {...field} />
+													<Input placeholder="Writer's full legal name" hasError={!!errors.writer} errormessage={errors.writer?.message} {...field} />
 												</FormControl>
 											</FormItem>
 										)}

--- a/src/app/artiste/(main)/catalog/misc/components/AudioCard.tsx
+++ b/src/app/artiste/(main)/catalog/misc/components/AudioCard.tsx
@@ -76,7 +76,7 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 		description: audio.description || '',
 		recordLabel: audio.recordLabel || '',
 		publisher: audio.publisher || '',
-		writer: (audio as any).writer || '',
+		writer: audio.writer || '',
 		copyright: audio.copyright || '',
 		explicitContent: audio.explicitContent || 'No',
 		lyrics: audio.lyrics || '',
@@ -231,7 +231,7 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 			</div>
 			<footer className="px-3">
 				<h6>{audio.title}</h6>
-				{(audio as any).reviewStatus === 'rejected' && (
+				{audio.reviewStatus === 'rejected' && (
 					<button type="button" onClick={openEditSheet} className="mt-1 inline-flex items-center gap-1 rounded-full bg-red-500/15 px-2 py-0.5 text-[11px] font-medium text-red-500 hover:bg-red-500/25">
 						Rejected — edit to resubmit
 					</button>
@@ -264,11 +264,11 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 								</div>
 							</div>
 
-							{(audio as any).reviewStatus === 'rejected' && Array.isArray((audio as any).rejectionReasons) && (audio as any).rejectionReasons.length > 0 && (
+							{audio.reviewStatus === 'rejected' && Array.isArray(audio.rejectionReasons) && audio.rejectionReasons.length > 0 && (
 								<div className="mx-4 mb-4 rounded-lg border border-red-500/40 bg-red-500/10 p-3">
 									<p className="text-sm font-semibold text-red-400 mb-1">This release was rejected. Please fix and resubmit:</p>
 									<ul className="list-disc list-inside text-sm text-red-300 space-y-0.5">
-										{(audio as any).rejectionReasons.map((r: string, i: number) => (
+										{audio.rejectionReasons.map((r: string, i: number) => (
 											<li key={i}>{r}</li>
 										))}
 									</ul>
@@ -487,7 +487,7 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 													</TooltipProvider>
 												</FormLabel>
 												<FormControl>
-													<Input placeholder="Writer's full legal name" hasError={!!(errors as any).writer} errormessage={(errors as any).writer?.message} {...field} />
+													<Input placeholder="Writer's full legal name" hasError={!!errors.writer} errormessage={errors.writer?.message} {...field} />
 												</FormControl>
 											</FormItem>
 										)}


### PR DESCRIPTION
Amplify build failed on `@typescript-eslint/no-explicit-any` (next build runs ESLint). Type reviewStatus/rejectionReasons/writer on TArtistMedia/TArtisteAlbum and remove the `as any` casts in AudioCard/AlbumCard. `npm run build` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)