### PR TITLE
fix: don't post server-managed objects on edit (fixes save crash)

### DIFF
--- a/src/app/artiste/(main)/catalog/misc/api/putUpdateArtisteAlbum.ts
+++ b/src/app/artiste/(main)/catalog/misc/api/putUpdateArtisteAlbum.ts
@@ -5,7 +5,25 @@ import { TArtisteAlbum } from './getArtisteAlbums';
 export const updateSingleTrack = async (payload: Partial<TArtisteAlbum>) => {
 	if (!payload._id) return;
 
-	const response = await APIAxios.put(`/media/update_album/${payload._id}`, payload, {
+	const formData = new FormData();
+
+	// Server-managed / non-updatable fields. `fugaDelivery` is an embedded
+	// object and `fileIds` is an array of track objects — neither should be
+	// posted back (they'd stringify to "[object Object]" and break the update).
+	const SKIP = ['_id', 'id', '__v', 'createdAt', 'updatedAt', 'artistId', 'fugaDelivery', 'reviewStatus', 'rejectionReasons', 'reviewedAt', 'reviewedBy', 'isStorageCleaned', 'fileIds'];
+
+	Object.entries(payload).forEach(([key, value]) => {
+		if (SKIP.includes(key) || value === undefined || value === null) return;
+		if (Array.isArray(value)) {
+			value.forEach(item => formData.append(key, String(item)));
+		} else if (typeof value === 'object') {
+			return;
+		} else {
+			formData.append(key, String(value));
+		}
+	});
+
+	const response = await APIAxios.put(`/media/update_album/${payload._id}`, formData, {
 		headers: {
 			'Content-Type': 'multipart/form-data'
 		}

--- a/src/app/artiste/(main)/catalog/misc/api/putUpdateArtisteMedia.ts
+++ b/src/app/artiste/(main)/catalog/misc/api/putUpdateArtisteMedia.ts
@@ -7,10 +7,18 @@ export const updateSingleTrack = async (payload: { data: Partial<TArtistMedia>; 
 
 	const formData = new FormData();
 
+	// Server-managed fields must never be posted back. In particular
+	// `fugaDelivery` is an embedded object that would be stringified to
+	// "[object Object]" and break the update with a Mongoose CastError.
+	const SKIP = ['_id', 'id', '__v', 'createdAt', 'updatedAt', 'artistId', 'fugaDelivery', 'reviewStatus', 'rejectionReasons', 'reviewedAt', 'reviewedBy', 'isStorageCleaned', 'fileIds'];
+
 	Object.entries(payload.data).forEach(([key, value]) => {
-		if (key === '_id' || value === undefined || value === null) return;
+		if (SKIP.includes(key) || value === undefined || value === null) return;
 		if (Array.isArray(value)) {
 			value.forEach(item => formData.append(key, String(item)));
+		} else if (typeof value === 'object') {
+			// Never stringify a nested object into "[object Object]".
+			return;
 		} else {
 			formData.append(key, String(value));
 		}


### PR DESCRIPTION
Skip fugaDelivery and other server-managed fields when building the update payload; build proper FormData for album edits. Pairs with the backend strip fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)