### PR TITLE
feat(upload): validate cover dimensions when the image is picked

### DIFF
--- a/src/app/artiste/(main)/catalog/misc/components/AudioCard.tsx
+++ b/src/app/artiste/(main)/catalog/misc/components/AudioCard.tsx
@@ -3,6 +3,7 @@ import { toast } from 'sonner';
 import Image from 'next/image';
 import { Play, Pause, Ellipsis, Eye, Trash, Edit2, ArrowRight, ImagePlus, Info } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { validateArtworkFile } from '@/lib/artwork';
 import { format } from 'date-fns';
 import { Musicnote, TickCircle } from 'iconsax-react';
 import { useForm } from 'react-hook-form';
@@ -52,7 +53,7 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 	const [coverArtPreview, setCoverArtPreview] = useState<string | null>(null);
 	const coverArtInputRef = useRef<HTMLInputElement>(null);
 
-	const handleCoverArtChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+	const handleCoverArtChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
 		const file = e.target.files?.[0];
 		if (!file) return;
 		const validTypes = ['image/png', 'image/jpeg', 'image/jpg'];
@@ -62,6 +63,11 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 		}
 		if (file.size > 5 * 1024 * 1024) {
 			toast.error('Cover art is too large. Max size is 5MB.');
+			return;
+		}
+		const dimensionError = await validateArtworkFile(file);
+		if (dimensionError) {
+			toast.error(dimensionError);
 			return;
 		}
 		setCoverArtFile(file);

--- a/src/app/artiste/(main)/upload/misc/components/Step3AlbumCoverUpload.tsx
+++ b/src/app/artiste/(main)/upload/misc/components/Step3AlbumCoverUpload.tsx
@@ -3,6 +3,7 @@
 import type React from 'react';
 import { useRef, useState, useEffect } from 'react';
 import { useAlbumUploadStore } from '../store';
+import { validateArtworkFile } from '@/lib/artwork';
 import { toast } from 'sonner';
 import { MoveLeft, MoveRight } from 'lucide-react';
 import { Button } from '@/components/ui';
@@ -53,6 +54,12 @@ const Step3AlbumCoverUpload = () => {
 		// Validate file size (5MB max)
 		if (file.size > 5 * 1024 * 1024) {
 			toast.error('File size exceeds the 5MB limit. Please upload a smaller file.');
+			return;
+		}
+
+		const dimensionError = await validateArtworkFile(file);
+		if (dimensionError) {
+			toast.error(dimensionError);
 			return;
 		}
 
@@ -113,6 +120,12 @@ const Step3AlbumCoverUpload = () => {
 			return;
 		}
 
+		const dimensionError = await validateArtworkFile(file);
+		if (dimensionError) {
+			toast.error(dimensionError);
+			return;
+		}
+
 		setUploadedFile(file);
 
 		// Create a preview URL
@@ -161,7 +174,7 @@ const Step3AlbumCoverUpload = () => {
 						<h3 className="text-base font-semibold mb-4">Track upload requirements</h3>
 						<ul className="list-disc pl-6 space-y-2 text-[0.9rem] text-white/70 text-left">
 							<li>File format: JPG, PNG, JPEG</li>
-							<li>Size: at least 3000×3000 pixels</li>
+							<li>Dimensions: exactly 1400×1400 or 3000×3000 pixels (square)</li>
 							<li>File size: Image file size cannot be greater than 5 MB</li>
 							<li>Color mode: Best quality RGB (including black and white images)</li>
 							<li>Resolution: 72 dpi</li>

--- a/src/app/artiste/(main)/upload/misc/components/Step3MediaCoverUpload.tsx
+++ b/src/app/artiste/(main)/upload/misc/components/Step3MediaCoverUpload.tsx
@@ -11,6 +11,7 @@ import { AppLogo } from '@/components/icons';
 import { cn } from '@/lib/utils';
 
 import { useMediaUploadStore } from '../store';
+import { validateArtworkFile } from '@/lib/artwork';
 
 const Step3MediaCoverUpload = () => {
 	const { setCoverArt, setCurrentStep, coverArtId, mediaInfo, getCoverArtFile, initializeDB, isDBInitialized } = useMediaUploadStore();
@@ -63,6 +64,12 @@ const Step3MediaCoverUpload = () => {
 		// Validate file size (5MB max)
 		if (file.size > 5 * 1024 * 1024) {
 			toast.error('File size exceeds the 5MB limit. Please upload a smaller file.');
+			return;
+		}
+
+		const dimensionError = await validateArtworkFile(file);
+		if (dimensionError) {
+			toast.error(dimensionError);
 			return;
 		}
 
@@ -120,6 +127,12 @@ const Step3MediaCoverUpload = () => {
 		// Validate file size (5MB max)
 		if (file.size > 5 * 1024 * 1024) {
 			toast.error('File size exceeds the 5MB limit. Please upload a smaller file.');
+			return;
+		}
+
+		const dimensionError = await validateArtworkFile(file);
+		if (dimensionError) {
+			toast.error(dimensionError);
 			return;
 		}
 
@@ -182,7 +195,7 @@ const Step3MediaCoverUpload = () => {
 						<h3 className="text-base font-semibold mb-4">Thumbnail upload requirements</h3>
 						<ul className="list-disc pl-6 space-y-2 text-[0.9rem] text-white/70 text-left">
 							<li>File format: JPG, PNG, JPEG</li>
-							<li>Size: at least 3000×3000 pixels</li>
+							<li>Dimensions: exactly 1400×1400 or 3000×3000 pixels (square)</li>
 							<li>File size: Image file size cannot be greater than 5 MB</li>
 							<li>Color mode: Best quality RGB (including black and white images)</li>
 							<li>Resolution: 72 dpi</li>

--- a/src/lib/artwork.ts
+++ b/src/lib/artwork.ts
@@ -1,0 +1,42 @@
+// Cover-art dimension rules, mirrored from the backend artwork validator so
+// the artist gets the error the moment they pick the image — not after filling
+// out the whole upload form.
+
+export const ALLOWED_ARTWORK_SIDES = [1400, 3000];
+
+/** Read an image File's pixel dimensions in the browser. */
+export const readImageDimensions = (file: File): Promise<{ width: number; height: number }> =>
+	new Promise((resolve, reject) => {
+		const url = URL.createObjectURL(file);
+		const img = new window.Image();
+		img.onload = () => {
+			URL.revokeObjectURL(url);
+			resolve({ width: img.naturalWidth, height: img.naturalHeight });
+		};
+		img.onerror = () => {
+			URL.revokeObjectURL(url);
+			reject(new Error('Could not read image'));
+		};
+		img.src = url;
+	});
+
+/**
+ * Validate a cover-art File against the dimension rules.
+ * Returns an error message string if invalid, or null if it's good.
+ */
+export const validateArtworkFile = async (file: File): Promise<string | null> => {
+	let dims: { width: number; height: number };
+	try {
+		dims = await readImageDimensions(file);
+	} catch {
+		return 'Could not read that image. Please upload a valid JPG or PNG.';
+	}
+	const { width, height } = dims;
+	if (width !== height) {
+		return `Cover art must be square — yours is ${width}×${height}. Use 1400×1400 or 3000×3000.`;
+	}
+	if (!ALLOWED_ARTWORK_SIDES.includes(width)) {
+		return `Cover art must be exactly 1400×1400 or 3000×3000 — yours is ${width}×${height}.`;
+	}
+	return null;
+};


### PR DESCRIPTION
Check artwork dimensions client-side the moment the cover is selected (upload + edit) instead of only at final submit, so the artist gets the error immediately. Fixes the misleading on-screen requirement text too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)