### PR TITLE
fix(catalog): type AudioCard update onError to unblock the build

### DIFF
--- a/src/app/artiste/(main)/catalog/misc/components/AudioCard.tsx
+++ b/src/app/artiste/(main)/catalog/misc/components/AudioCard.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useCallback } from 'react';
+import { AxiosError } from 'axios';
 import { toast } from 'sonner';
 import Image from 'next/image';
 import { Play, Pause, Ellipsis, Eye, Trash, Edit2, ArrowRight, ImagePlus, Info } from 'lucide-react';
@@ -117,8 +118,9 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 					setCoverArtPreview(null);
 					setIsEditSheetState(false);
 				},
-				onError() {
-					toast.error('Failed to update audio track');
+				onError(error: Error | AxiosError<{ message?: string }>) {
+					const message = error instanceof AxiosError ? error.response?.data?.message : undefined;
+					toast.error(message || 'Failed to update audio track');
 				}
 			}
 		);


### PR DESCRIPTION
## Summary
The production build (`npm run build`) was failing on a `no-explicit-any` ESLint error in `AudioCard.tsx`. This types the mutation's `onError` callback as `Error | AxiosError<{ message?: string }>` and narrows with `instanceof AxiosError` before reading the response message, matching the existing repo convention (e.g. `MatchArtistForm.tsx`).

## Test plan
- [x] `npm run build` compiles successfully (50/50 static pages generated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)