### PR TITLE
feat(upload): clarify Publisher field expects full legal name via tooltip

### DIFF
--- a/src/app/artiste/(main)/upload/misc/components/Step1AlbumInfo.tsx
+++ b/src/app/artiste/(main)/upload/misc/components/Step1AlbumInfo.tsx
@@ -235,7 +235,7 @@ export default function Step1MusicInfo() {
 							name="publisher"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>
+									<FormLabel info="Enter the publisher's full legal name (the registered legal entity or person), not an abbreviation or stage name.">
 										Publisher <span className="text-primary">*</span>
 									</FormLabel>
 									<FormControl>

--- a/src/app/artiste/(main)/upload/misc/components/Step1MediaInfo.tsx
+++ b/src/app/artiste/(main)/upload/misc/components/Step1MediaInfo.tsx
@@ -186,7 +186,7 @@ export default function Step1MusicInfo() {
 							name="publisher"
 							render={({ field }) => (
 								<FormItem>
-									<FormLabel>Publisher</FormLabel>
+									<FormLabel info="Enter the publisher's full legal name (the registered legal entity or person), not an abbreviation or stage name.">Publisher</FormLabel>
 									<FormControl>
 										<Input placeholder="Enter publisher" hasError={!!errors.publisher} errormessage={errors.publisher?.message} {...field} />
 									</FormControl>

--- a/src/app/artiste/(main)/upload/misc/components/Step2AlbumTrackUpload.tsx
+++ b/src/app/artiste/(main)/upload/misc/components/Step2AlbumTrackUpload.tsx
@@ -367,7 +367,7 @@ function TrackEditSheet({ isOpen, onClose, track, albumInfo, onSave, genreOption
 									render={({ field }) => (
 										<FormItem className="w-full">
 											<div className="flex items-center justify-between">
-												<FormLabel>Publisher</FormLabel>
+												<FormLabel info="Enter the publisher's full legal name (the registered legal entity or person), not an abbreviation or stage name.">Publisher</FormLabel>
 												<div className="flex items-center gap-2 ml-4">
 													<Checkbox id="samePublisher" checked={sameAsAlbum.publisher} onCheckedChange={() => toggleSameAsAlbum('publisher')} />
 													<Label htmlFor="samePublisher" className="text-[0.7rem] md:text-sm text-white/40">


### PR DESCRIPTION
## Summary
Adds an info-icon tooltip next to the **Publisher** field throughout the upload flow, clarifying that it expects the publisher's full legal name (not an abbreviation or stage name). Uses the existing `FormLabel info="..."` tooltip pattern already used by other fields (Featured Artists, UPC, Copyright, etc.).

## Changes
- `Step1AlbumInfo.tsx` — album publisher
- `Step1MediaInfo.tsx` — single/track publisher
- `Step2AlbumTrackUpload.tsx` — per-track publisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)