### PR TITLE
fix(errors): surface server error messages instead of generic placeholder

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,119 +1,123 @@
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-import { InferType } from "yup";
-import { musicInfoSchema } from "./schemas";
-import { PreviewTableProps } from "@/components/preview-table/preview-table";
-import { formatDate } from "date-fns";
-import { plusJakartaSans } from "./fonts";
-import { AxiosError } from "axios";
-import { toast } from "sonner";
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+import { InferType } from 'yup';
+import { musicInfoSchema } from './schemas';
+import { PreviewTableProps } from '@/components/preview-table/preview-table';
+import { formatDate } from 'date-fns';
+import { plusJakartaSans } from './fonts';
+import { AxiosError } from 'axios';
+import { toast } from 'sonner';
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+	return twMerge(clsx(inputs));
 }
 
 export function convertFileSize(size: number) {
-  const mb = 1000 * 1024;
-  const kb = 1024;
+	const mb = 1000 * 1024;
+	const kb = 1024;
 
-  if (size >= mb) {
-    return `${(size / mb).toFixed(2)} MB`;
-  }
-  if (size >= kb) {
-    return `${(size / kb).toFixed(2)} KB`;
-  }
-  return `${(size / 1024).toFixed(2)} KB`;
+	if (size >= mb) {
+		return `${(size / mb).toFixed(2)} MB`;
+	}
+	if (size >= kb) {
+		return `${(size / kb).toFixed(2)} KB`;
+	}
+	return `${(size / 1024).toFixed(2)} KB`;
 }
 
-export const generateMusicUploadPreview = (
-  musicInfo: InferType<typeof musicInfoSchema>
-): PreviewTableProps["previewData"] => {
-  const date = new Date(musicInfo.release_date);
-  const shortDate = formatDate(date, "dd MMM, yyyy");
+export const generateMusicUploadPreview = (musicInfo: InferType<typeof musicInfoSchema>): PreviewTableProps['previewData'] => {
+	const date = new Date(musicInfo.release_date);
+	const shortDate = formatDate(date, 'dd MMM, yyyy');
 
-  return [
-    [
-      {
-        title: "Song Title",
-        value: musicInfo.song_title,
-      },
-      {
-        title: "Artist Name",
-        value: musicInfo.publisher,
-      },
-      {
-        title: "Release Date",
-        value: shortDate,
-      },
-      {
-        title: "Genre",
-        value: musicInfo.genre,
-      },
-    ],
+	return [
+		[
+			{
+				title: 'Song Title',
+				value: musicInfo.song_title
+			},
+			{
+				title: 'Artist Name',
+				value: musicInfo.publisher
+			},
+			{
+				title: 'Release Date',
+				value: shortDate
+			},
+			{
+				title: 'Genre',
+				value: musicInfo.genre
+			}
+		],
 
-    [
-      {
-        title: "Release Year",
-        value: date.getFullYear().toString(),
-      },
-      {
-        title: "Music Description",
-        value: musicInfo.description,
-      },
-    ],
-  ];
+		[
+			{
+				title: 'Release Year',
+				value: date.getFullYear().toString()
+			},
+			{
+				title: 'Music Description',
+				value: musicInfo.description
+			}
+		]
+	];
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const generateRevenuChartPlugins: () => any = () => {
-  return {
-    plugins: {
-      tooltip: {
-        backgroundColor: "rgba(0,0,0)",
-        bodyFont: {
-          family: plusJakartaSans.style.fontFamily,
-          weight: 600,
-          size: 12,
-        },
+	return {
+		plugins: {
+			tooltip: {
+				backgroundColor: 'rgba(0,0,0)',
+				bodyFont: {
+					family: plusJakartaSans.style.fontFamily,
+					weight: 600,
+					size: 12
+				},
 
-        caretSize: 10,
-        bodyAlign: "center",
-        axis: "y",
-      },
-      legend: {
-        display: false,
-      },
-    },
-    scales: {
-      x: {
-        grid: {
-          display: false,
-        },
-      },
-      y: {
-        grid: {
-          color: "#4D4D4D",
-          lineWidth: 1,
-        },
-      },
-    },
-    font: {
-      family: plusJakartaSans.style.fontFamily,
-    },
-    color: "white",
-  };
+				caretSize: 10,
+				bodyAlign: 'center',
+				axis: 'y'
+			},
+			legend: {
+				display: false
+			}
+		},
+		scales: {
+			x: {
+				grid: {
+					display: false
+				}
+			},
+			y: {
+				grid: {
+					color: '#4D4D4D',
+					lineWidth: 1
+				}
+			}
+		},
+		font: {
+			family: plusJakartaSans.style.fontFamily
+		},
+		color: 'white'
+	};
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const handleClientError = (error: any) => {
-  if (error instanceof AxiosError) {
-    if (error.code === "500") {
-      toast.error("Something went wrong. Try again");
-    } else {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      toast.error((error.response as any)?.data.message as string);
-    }
-    return;
-  }
-  toast.error("Something went wrong. Try again");
+	if (error instanceof AxiosError) {
+		const status = error.response?.status;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const rawMessage = (error.response?.data as any)?.message;
+		const serverMessage = Array.isArray(rawMessage) ? rawMessage.join(', ') : (rawMessage as string | undefined);
+
+		if (status && status >= 500) {
+			toast.error('Something went wrong on our end. Please try again.');
+		} else if (serverMessage) {
+			toast.error(serverMessage);
+		} else {
+			toast.error('Something went wrong. Try again');
+		}
+		return;
+	}
+	toast.error('Something went wrong. Try again');
 };

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -24,8 +24,9 @@ export const handleInactiveAccountRedirect = () => {
 APIAxios.interceptors.response.use(
 	response => response,
 	error => {
-		if (error?.status == 500) {
-			toast.error('We are having a problem on our end -- SERVER ERROR PLACEHOLDER', { duration: 10000, id: '900' });
+		const status = error?.response?.status ?? error?.status;
+		if (status >= 500) {
+			toast.error('Something went wrong on our end. Please try again.', { duration: 10000, id: '900' });
 			return Promise.reject(error);
 		}
 		/*if (error?.message === 'Network Error' || error?.code == 'ERR_NETWORK') {


### PR DESCRIPTION
## Summary
Fixes frontend error handling so backend error messages reach the user instead of always showing a generic placeholder.

- `utils/axios.ts`: interceptor reads `error.response?.status`; friendly 5xx wording (removed "SERVER ERROR PLACEHOLDER"). 4xx pass through to local handlers.
- `lib/utils.ts` (`handleClientError`): fixed broken `error.code === "500"` check; now surfaces `error.response?.data?.message` (handles array messages) with a friendly generic for 5xx.

Pairs with the backend change returning a 409 + message on duplicate email, so users now see e.g. "This email is already in use by another account."

🤖 Generated with [Claude Code](https://claude.com/claude-code)