### PR TITLE
feat(onboarding): remove yearly registration-fee subscription

### DIFF
--- a/src/app/artiste/(auth)/onboarding/_components/preview-onboarding/preview-onboarding.tsx
+++ b/src/app/artiste/(auth)/onboarding/_components/preview-onboarding/preview-onboarding.tsx
@@ -4,12 +4,14 @@ import { Button } from '@/components/ui/button';
 import { OnboardingSteps } from '@/lib/constants';
 import React from 'react';
 import { useAuthContext } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
 
 interface PreviewOnboardingProps {
 	setCurrentStep: (a: OnboardingSteps) => void;
 }
 const PreviewOnboarding = ({ setCurrentStep }: PreviewOnboardingProps) => {
 	const { artist } = useAuthContext();
+	const router = useRouter();
 	const data = [
 		[
 			{
@@ -71,7 +73,7 @@ const PreviewOnboarding = ({ setCurrentStep }: PreviewOnboardingProps) => {
 					<Button size={'lg'} className="max-w-[275px] bg-transparent border-2 border-white h-[75px] " onClick={() => setCurrentStep(OnboardingSteps.BASIC_DETAIL)}>
 						Edit
 					</Button>
-					<Button size={'lg'} className="max-w-[275px] h-[75px] " onClick={() => setCurrentStep(OnboardingSteps.PAY_REGISTRATION_FEE)}>
+					<Button size={'lg'} className="max-w-[275px] h-[75px] " onClick={() => router.push('/artiste/dashboard')}>
 						Continue
 					</Button>
 				</div>

--- a/src/app/artiste/(auth)/onboarding/onboarding.client.tsx
+++ b/src/app/artiste/(auth)/onboarding/onboarding.client.tsx
@@ -8,32 +8,27 @@ import PreviewOnboarding from './_components/preview-onboarding/preview-onboardi
 import React, { useState } from 'react';
 import { useAuthContext } from '@/contexts/AuthContext';
 // import { getArtistProfile } from '@/contexts/AuthContextArtist';
-import { redirect, useSearchParams } from 'next/navigation';
+import { redirect } from 'next/navigation';
 import { Spinner } from '@/components/icons';
-import RegistrationPaymentPage from './_components/payment-registration-fee';
 
 const OnboardingClientPage = () => {
 	const { artist, isLoading } = useAuthContext();
-	const searchParams = useSearchParams();
-	const forceStep = searchParams.get('step') ? OnboardingSteps.PAY_REGISTRATION_FEE : onboardingStages[artist!.stage];
-	const [currentStep, setCurrentStep] = useState(forceStep || OnboardingSteps.BASIC_DETAIL);
+	const currentStepFromStage = onboardingStages[artist!.stage];
+	const [currentStep, setCurrentStep] = useState(currentStepFromStage || OnboardingSteps.BASIC_DETAIL);
 	const screens = {
 		[OnboardingSteps.BASIC_DETAIL]: <OnboardingBasciDetail email={artist?.email || ''} setCurrentStep={setCurrentStep} />,
 		[OnboardingSteps.BANK]: <OnboardingBankDetail setCurrentStep={setCurrentStep} email={artist?.email || ''} />,
 		[OnboardingSteps.SOCIAL_LINK]: <OnboardingSocialMedia email={artist?.email || ''} setCurrentStep={setCurrentStep} />,
-		[OnboardingSteps.PREVIEW]: <PreviewOnboarding setCurrentStep={setCurrentStep} />,
-		[OnboardingSteps.PAY_REGISTRATION_FEE]: <RegistrationPaymentPage email={artist?.email || ''} />
+		[OnboardingSteps.PREVIEW]: <PreviewOnboarding setCurrentStep={setCurrentStep} />
 	};
 
 	React.useEffect(() => {
 		if (!isLoading && !artist) {
 			redirect('/artiste/login');
-		} else if (!!artist && artist?.stage == 'complete' && !forceStep) {
+		} else if (!!artist && artist?.stage == 'complete') {
 			redirect('/artiste/dashboard');
-		} else if (!!artist && (artist.stage === 'Add social links' || artist.stage === 'complete') && !artist.bankDetails.paidRegistrationFee) {
-			setCurrentStep(OnboardingSteps.PAY_REGISTRATION_FEE);
 		}
-	}, [isLoading, artist, forceStep]);
+	}, [isLoading, artist]);
 
 	if (isLoading) {
 		return (

--- a/src/app/artiste/(main)/dashboard/page.tsx
+++ b/src/app/artiste/(main)/dashboard/page.tsx
@@ -4,7 +4,7 @@ import { useGetDashboardData } from './misc/api';
 import { formatCurrency } from '@/utils/currency';
 import { RevenueHistoryChart, StreamsHistoryChart } from './misc/components';
 import { Icon } from '@iconify/react/dist/iconify.js';
-import { AlertTriangle, BarChart2, ChevronsRight, Gift, Globe, Music } from 'lucide-react';
+import { AlertTriangle, BarChart2, ChevronsRight, Globe, Music } from 'lucide-react';
 import { LinkButton } from '@/components/ui';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { useCurrency, Currency } from '@/app/artiste/context/CurrencyContext';
@@ -89,28 +89,6 @@ const MusicDashboard = () => {
 
 	return (
 		<div className="container mx-auto px-4 py-6">
-			{artist?.bankDetails?.paidRegistrationFee === false && artist?.usedFreeUpload !== true && (
-				<div className="mb-6 flex items-center gap-3 rounded-lg border border-emerald-300 bg-emerald-50 dark:bg-emerald-950/30 dark:border-emerald-700 p-4">
-					<Gift className="h-5 w-5 text-emerald-600 shrink-0" />
-					<p className="text-sm text-emerald-800 dark:text-emerald-200 flex-1 font-medium">
-						You have <span className="font-bold">1 free track upload</span> — distribute a single to stores for free. Pay the registration fee to upload more.
-					</p>
-					<LinkButton href="/artiste/upload" size="thin" className="text-xs rounded-full shrink-0">
-						Upload Free
-					</LinkButton>
-				</div>
-			)}
-
-			{artist?.bankDetails?.paidRegistrationFee === false && artist?.usedFreeUpload === true && (
-				<div className="mb-6 flex items-center gap-3 rounded-lg border border-rose-300 bg-rose-50 dark:bg-rose-950/30 dark:border-rose-700 p-4">
-					<AlertTriangle className="h-5 w-5 text-rose-600 shrink-0" />
-					<p className="text-sm text-rose-800 dark:text-rose-200 flex-1 font-medium">You&apos;ve used your free track upload. Pay the registration fee to upload more.</p>
-					<LinkButton href="/artiste/onboarding?step=registration_fee" size="thin" className="text-xs rounded-full shrink-0">
-						Pay Now
-					</LinkButton>
-				</div>
-			)}
-
 			{artist?.contractDetails?.status === 'PENDING_SIGNATURE' && (
 				<div className="mb-6 flex items-center gap-3 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-4">
 					<AlertTriangle className="h-5 w-5 text-amber-600 shrink-0" />

--- a/src/app/artiste/(main)/misc/components/NotificationBell.tsx
+++ b/src/app/artiste/(main)/misc/components/NotificationBell.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Bell, CreditCard, FileSignature, AlertTriangle } from 'lucide-react';
+import { Bell, FileSignature, AlertTriangle } from 'lucide-react';
 import Link from 'next/link';
 import { useAuthContext } from '@/contexts/AuthContext';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
@@ -20,14 +20,6 @@ const NotificationBell = () => {
 	const { data: albumsData } = useGetAlbums({ page: 1, limit: 100 });
 
 	const notifications: Notification[] = [];
-
-	if (artist?.bankDetails?.paidRegistrationFee === false) {
-		notifications.push({
-			label: 'Pay registration fee',
-			href: '/artiste/onboarding?step=registration_fee',
-			icon: <CreditCard className="h-4 w-4 text-muted-foreground shrink-0" />
-		});
-	}
 
 	if (artist?.contractDetails?.status === 'PENDING_SIGNATURE') {
 		notifications.push({

--- a/src/app/artiste/(main)/upload/page.tsx
+++ b/src/app/artiste/(main)/upload/page.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 'use client';
 import { useState, useEffect } from 'react';
-import { Button, LinkButton } from '@/components/ui';
-import { AlertTriangle, Gift, MoveRight } from 'lucide-react';
+import { Button } from '@/components/ui';
+import { AlertTriangle, MoveRight } from 'lucide-react';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { redirect, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useMediaUploadStore } from './misc/store';
 import { useAlbumUploadStore } from './misc/store';
 import { cn } from '@/lib/utils';
@@ -53,17 +53,6 @@ export default function MediaTypeSelection() {
 	const [selectedType, setSelectedType] = useState<string | null>(mediaType);
 	const [showContinueDialog, setShowContinueDialog] = useState(false);
 
-	const hasPaid = !!artist?.bankDetails?.paidRegistrationFee;
-	// Unpaid artists get one free single upload before the paywall.
-	const canFreeUpload = !!artist && !hasPaid && !artist.usedFreeUpload;
-
-	useEffect(() => {
-		// Only bounce to the paywall once the free upload has been used.
-		if (artist && !hasPaid && !canFreeUpload) {
-			router.replace('/artiste/onboarding?step=registration_fee');
-		}
-	}, [artist, hasPaid, canFreeUpload, router]);
-
 	useEffect(() => {
 		if (mediaType) {
 			setSelectedType(mediaType);
@@ -76,13 +65,6 @@ export default function MediaTypeSelection() {
 
 	const handleContinue = async () => {
 		if (!selectedType) return;
-
-		const isAlbumType = selectedType === 'Album' || selectedType === 'ExtendedPlaylist' || selectedType === 'MixTape';
-		// The free upload covers a single track/video only. Albums (and any
-		// upload once the free credit is spent) still require payment.
-		if (!hasPaid && (isAlbumType || !canFreeUpload)) {
-			redirect('/artiste/onboarding?step=registration_fee');
-		}
 
 		// setMediaType(selectedType as any);
 		if (selectedType === 'Album' || selectedType === 'ExtendedPlaylist' || selectedType === 'MixTape') {
@@ -136,25 +118,6 @@ export default function MediaTypeSelection() {
 				<div className="mb-6 flex items-center gap-3 rounded-lg border border-amber-300 bg-amber-50 dark:bg-amber-950/30 dark:border-amber-700 p-4">
 					<AlertTriangle className="h-5 w-5 text-amber-600 shrink-0" />
 					<p className="text-sm text-amber-800 dark:text-amber-200 flex-1 font-medium">Your distribution has been paused. Uploads are temporarily disabled. Please contact support for assistance.</p>
-				</div>
-			)}
-
-			{canFreeUpload && (
-				<div className="mb-6 flex items-center gap-3 rounded-lg border border-emerald-300 bg-emerald-50 dark:bg-emerald-950/30 dark:border-emerald-700 p-4">
-					<Gift className="h-5 w-5 text-emerald-600 shrink-0" />
-					<p className="text-sm text-emerald-800 dark:text-emerald-200 flex-1 font-medium">
-						You have <span className="font-bold">1 free track upload</span> — upload a single now to get it distributed to stores. Albums and additional tracks require paying the registration fee.
-					</p>
-				</div>
-			)}
-
-			{!hasPaid && !canFreeUpload && (
-				<div className="mb-6 flex items-center gap-3 rounded-lg border border-rose-300 bg-rose-50 dark:bg-rose-950/30 dark:border-rose-700 p-4">
-					<AlertTriangle className="h-5 w-5 text-rose-600 shrink-0" />
-					<p className="text-sm text-rose-800 dark:text-rose-200 flex-1 font-medium">Complete your registration by paying the registration fee</p>
-					<LinkButton href="/artiste/onboarding?step=registration_fee" size="thin" className="text-xs rounded-full shrink-0">
-						Pay Now
-					</LinkButton>
 				</div>
 			)}
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -137,8 +137,7 @@ export enum OnboardingSteps {
 	BASIC_DETAIL,
 	BANK,
 	SOCIAL_LINK,
-	PREVIEW,
-	PAY_REGISTRATION_FEE
+	PREVIEW
 }
 
 export const metricsDate = ['daily', 'monthly', 'yearly'];
@@ -287,7 +286,10 @@ export const onboardingStages = {
 	[userProfileStage.bankInfo]: OnboardingSteps.BANK,
 	[userProfileStage.onboarding]: OnboardingSteps.BASIC_DETAIL,
 	[userProfileStage.socialLinks]: OnboardingSteps.SOCIAL_LINK,
-	[userProfileStage.payment]: OnboardingSteps.PAY_REGISTRATION_FEE
+	// Registration fee removed: the old payment stage now resolves to the
+	// Preview step (whose CTA completes onboarding) so any artist still carrying
+	// this stage isn't bounced back to the start.
+	[userProfileStage.payment]: OnboardingSteps.PREVIEW
 };
 export const onboardingStagesKey = Object.keys(onboardingStages);
 


### PR DESCRIPTION
## What
Removes the yearly registration-fee subscription from the artist UI — onboarding and uploads are now free.

## Changes
- Onboarding ends at the Preview step; its CTA goes straight to the dashboard
- Remove the payment step, its `OnboardingSteps` enum value, and the force-to-payment redirect
- Remove the registration-fee banners on the dashboard and upload pages
- Remove the upload paywall gate and the "Pay registration fee" notification

## Reversible
The `payment-registration-fee` component is left in the tree but unreferenced.

Pairs with the backend PR (`remove-registration-fee`). Backend must be deployed for uploads to actually be free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)