### PR TITLE
Stop offering MP3 for album uploads; drop OGG from singles

### DIFF
--- a/src/app/artiste/(main)/upload/misc/components/Step2AlbumTrackUpload.tsx
+++ b/src/app/artiste/(main)/upload/misc/components/Step2AlbumTrackUpload.tsx
@@ -673,6 +673,18 @@ export default function TrackUpload() {
 		}
 	}, [mediaFileIds.length, albumTracks.length]);
 
+	// Validate by extension, not just MIME category: `file.type.includes('audio')`
+	// accepted MP3s regardless of the picker's accept list, and stores require
+	// lossless audio, so those albums were uploaded only to be marked
+	// undeliverable later. MIME is still checked to catch a renamed file.
+	const isValidTrackFile = (file: File) => {
+		const validExtensions = ['.wav', '.flac', '.mp4'];
+		const name = file.name.toLowerCase();
+		if (!validExtensions.some(ext => name.endsWith(ext))) return false;
+
+		return !file.type || file.type.startsWith('audio/') || file.type.startsWith('video/');
+	};
+
 	const handleFilesSelected = async (event: React.ChangeEvent<HTMLInputElement>) => {
 		const files = event.target.files;
 		if (!files || files.length === 0) return;
@@ -686,12 +698,12 @@ export default function TrackUpload() {
 				invalidFiles.push(`${file.name} (exceeds 512 MB)`);
 				continue;
 			}
-			if (file.type.includes('audio') || file.type.includes('video')) {
+			if (isValidTrackFile(file)) {
 				validFiles.push(file);
 
 				// Create a default track entry for this file
 				const newTrack: AlbumTrackInfo = {
-					title: file.name.replace(/\.(mp3|mp4|wav)$/i, ''),
+					title: file.name.replace(/\.(mp3|mp4|wav|flac)$/i, ''),
 					artistName: albumInfo.artistName,
 					primaryArtist2: albumInfo.primaryArtist2 || '',
 					featuredArtists: albumInfo.featuredArtists || '',
@@ -734,7 +746,7 @@ export default function TrackUpload() {
 
 		if (invalidFiles.length > 0) {
 			toast.error('Invalid files detected', {
-				description: `The following files are not valid: ${invalidFiles.join(', ')}`
+				description: `Tracks must be WAV or FLAC (or MP4 for video) — MP3 can't be distributed. Not accepted: ${invalidFiles.join(', ')}`
 			});
 		}
 
@@ -875,12 +887,12 @@ export default function TrackUpload() {
 					<Music width={100} height={100} className="" style={{ opacity: 0.3, filter: 'grayscale(1)' }} />
 				</div>
 				<div className="flex flex-col items-start justify-center">
-					<input type="file" className="hidden" ref={inputRef} onChange={handleFilesSelected} accept=".mp3,.mp4,.wav" multiple />
+					<input type="file" className="hidden" ref={inputRef} onChange={handleFilesSelected} accept=".wav,.flac,.mp4" multiple />
 
 					<div className="mb-6 text-left">
 						<h3 className="text-base font-semibold mb-4">Album upload requirements</h3>
 						<ul className="text-[0.9rem] text-white/70 space-y-1.5 text-left">
-							<li>• File format: MP3, MP4</li>
+							<li>• File format: WAV, FLAC (audio) or MP4 (video)</li>
 							<li>File size: Files size cannot be greater than 512 MB</li>
 							<li>• Video mode: Best quality</li>
 							<li>• Your track must not contain any logos, website address, release dates or advertisements of any kind.</li>

--- a/src/app/artiste/(main)/upload/misc/components/Step2MediaTrackUpload.tsx
+++ b/src/app/artiste/(main)/upload/misc/components/Step2MediaTrackUpload.tsx
@@ -24,7 +24,7 @@ export default function Step2MediaTrackUpload() {
 	// file whose reported MIME is in the wrong category so a renamed file can't slip through
 	// (e.g. a .wav renamed to .mp4 for a video upload, or vice-versa).
 	const isValidFileType = (file: File) => {
-		const validExtensions = isAudio ? ['.wav', '.ogg', '.flac'] : ['.mp4'];
+		const validExtensions = isAudio ? ['.wav', '.flac'] : ['.mp4'];
 		const name = file.name.toLowerCase();
 		const extensionOk = validExtensions.some(ext => name.endsWith(ext));
 		if (!extensionOk) return false;
@@ -35,7 +35,7 @@ export default function Step2MediaTrackUpload() {
 		return true;
 	};
 
-	const invalidFileTypeMessage = isAudio ? 'Invalid file type. Please upload WAV, OGG or FLAC files only.' : 'Invalid file type. Please upload MP4 files only.';
+	const invalidFileTypeMessage = isAudio ? 'Invalid file type. Please upload WAV or FLAC files only.' : 'Invalid file type. Please upload MP4 files only.';
 	const [videoUrl, setVideoUrl] = useState<string | null>(null);
 	const [uploadedFile, setUploadedFile] = useState<File | null>(null);
 	const [uploadProgress, setUploadProgress] = useState(0);
@@ -154,14 +154,14 @@ export default function Step2MediaTrackUpload() {
 					<p className="text-white/30 mb-6 text-xs max-w-[30ch] text-center text-balance">Drag and drop your audio file here, or click the button below</p>
 				</label>
 				<div className="flex flex-col items-start justify-center">
-					<input type="file" className="hidden" ref={fileInputRef} onChange={handleFileChange} accept={isAudio ? '.wav,.ogg,.flac' : '.mp4'} id="track-upload-input" />
+					<input type="file" className="hidden" ref={fileInputRef} onChange={handleFileChange} accept={isAudio ? '.wav,.flac' : '.mp4'} id="track-upload-input" />
 
 					<div className="mb-6 text-left">
 						<h3 className="text-base font-semibold mb-4">Track upload requirements</h3>
 						<ul className="list-disc pl-6 space-y-2 text-[0.9rem] text-white/70 text-left">
 							<li>
 								File format:
-								{isAudio ? ' WAV, OGG, FLAC' : 'MP4'}
+								{isAudio ? ' WAV, FLAC' : 'MP4'}
 							</li>
 							{isAudio && <li>Audio quality: 44.1kHz or greater, 16-bit stereo or 24-bit stereo</li>}
 							{!isAudio && <li>Video mode: Best quality</li>}


### PR DESCRIPTION
The MP3 restriction was only ever applied to the singles picker. Albums still offered it, which is why every ineligible album on production is ineligible for containing MP3 tracks.

| Picker | Before | After |
|---|---|---|
| `Step2AlbumTrackUpload` | `.mp3,.mp4,.wav` | `.wav,.flac,.mp4` |
| `Step2MediaTrackUpload` (single) | `.wav,.ogg,.flac` | `.wav,.flac` |

## Album picker

`accept` was only half the problem — validation was `file.type.includes('audio')`, so an MP3 was accepted regardless of the accept list (drag-and-drop, or any browser that doesn't enforce `accept`). It now validates by extension, mirroring the singles component, with the MIME category still checked so a renamed file can't slip through.

The rejection toast said "The following files are not valid", which doesn't tell the artist what to do. It now explains that tracks must be WAV or FLAC and that MP3 can't be distributed.

The requirements list also advertised "File format: MP3, MP4" — now WAV, FLAC (audio) or MP4 (video).

## Singles picker

Offered `.ogg`, which the backend rejects outright — an artist who picked an OGG file got "Invalid media type" after selecting it. Removed from the accept list, the validator, and the requirements text.

Pairs with the backend PR that makes the API reject MP3 for real (it was accepting them despite an error message saying otherwise).

## Testing

`tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)