### PR TITLE
Let artists replace a track's audio file

### DIFF
--- a/src/app/artiste/(main)/catalog/misc/api/putUpdateArtisteMedia.ts
+++ b/src/app/artiste/(main)/catalog/misc/api/putUpdateArtisteMedia.ts
@@ -1,11 +1,20 @@
 import APIAxios from '@/utils/axios';
 import { TArtistMedia } from './getArtisteMedias';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { uploadToS3 } from '../../../upload/misc/api/upload';
 
-export const updateSingleTrack = async (payload: { data: Partial<TArtistMedia>; coverArt?: File }) => {
+export const updateSingleTrack = async (payload: { data: Partial<TArtistMedia>; coverArt?: File; audioFile?: File }) => {
 	if (!payload.data._id) return;
 
 	const formData = new FormData();
+
+	// Replacing the audio itself: upload to S3 first, then send the new URL as
+	// `mediaUrl`. The API re-validates the format and re-checks whether the
+	// release (and its album) can now be delivered.
+	if (payload.audioFile) {
+		const mediaUrl = await uploadToS3(payload.audioFile);
+		payload.data = { ...payload.data, mediaUrl };
+	}
 
 	// Server-managed fields must never be posted back. In particular
 	// `fugaDelivery` is an embedded object that would be stringified to

--- a/src/app/artiste/(main)/catalog/misc/components/AudioCard.tsx
+++ b/src/app/artiste/(main)/catalog/misc/components/AudioCard.tsx
@@ -75,6 +75,30 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 		setCoverArtPreview(URL.createObjectURL(file));
 	}, []);
 
+	// Replacing the track's audio — the fix for a release rejected over its
+	// format. Blocked once the release is with stores, since swapping the file
+	// then needs a redelivery the artist can't trigger.
+	const audioFileInputRef = useRef<HTMLInputElement>(null);
+	const [audioFile, setAudioFile] = useState<File | null>(null);
+	const deliveryStatus = (audio as { fugaDelivery?: { status?: string } }).fugaDelivery?.status;
+	const canReplaceAudio = deliveryStatus !== 'delivered' && deliveryStatus !== 'delivering';
+
+	const handleAudioFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+		const file = e.target.files?.[0];
+		if (!file) return;
+
+		const name = file.name.toLowerCase();
+		if (!['.wav', '.flac'].some(ext => name.endsWith(ext))) {
+			toast.error("Audio must be WAV or FLAC — MP3 can't be delivered to stores.");
+			return;
+		}
+		if (file.size > 512 * 1024 * 1024) {
+			toast.error('File size exceeds the 512MB limit. Please upload a smaller file.');
+			return;
+		}
+		setAudioFile(file);
+	}, []);
+
 	const defaultValues: MediaUpdateFormValues = {
 		title: audio.title,
 		artistName: audio.artistName || '',
@@ -110,12 +134,13 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 			...data
 		};
 		updateMedia(
-			{ data: updatedAudio, coverArt: coverArtFile ?? undefined },
+			{ data: updatedAudio, coverArt: coverArtFile ?? undefined, audioFile: audioFile ?? undefined },
 			{
 				onSuccess() {
-					toast.success('Audio track updated successfully');
+					toast.success(audioFile ? 'Track replaced and sent back for review' : 'Audio track updated successfully');
 					setCoverArtFile(null);
 					setCoverArtPreview(null);
+					setAudioFile(null);
 					setIsEditSheetState(false);
 				},
 				onError(error: Error | AxiosError<{ message?: string }>) {
@@ -370,6 +395,25 @@ const AudioCard = ({ audio, album, selected }: { audio: TArtistMedia; album?: TA
 										{coverArtFile ? coverArtFile.name : 'Click to change cover art'}
 									</button>
 								</div>
+
+								{canReplaceAudio && (
+									<div className="flex flex-col gap-2 p-4 rounded-lg border border-border">
+										<p className="text-sm font-medium">Audio file</p>
+										<p className="text-xs text-white/50 break-all">{audioFile ? audioFile.name : (audio.mediaUrl || '').split('/').pop()}</p>
+										<input ref={audioFileInputRef} type="file" accept=".wav,.flac" className="hidden" onChange={handleAudioFileChange} />
+										<div className="flex items-center gap-3">
+											<Button type="button" variant="outline" size="sm" className="rounded-full" onClick={() => audioFileInputRef.current?.click()}>
+												Replace audio file
+											</Button>
+											{audioFile && (
+												<button type="button" className="text-xs text-white/50 hover:underline" onClick={() => setAudioFile(null)}>
+													Undo
+												</button>
+											)}
+										</div>
+										<p className="text-xs text-white/40">WAV or FLAC only — MP3 can&apos;t be delivered to stores. Replacing the file sends the release back for review.</p>
+									</div>
+								)}
 
 								<div className="grid grid-cols-1 gap-6">
 									<FormField

--- a/src/app/artiste/(main)/upload/misc/api/upload.ts
+++ b/src/app/artiste/(main)/upload/misc/api/upload.ts
@@ -6,7 +6,7 @@ import { UploadAlbumPayload, UploadTrackPayload } from '../types';
 import { MediaUploadInfo } from '../store/media';
 
 // Helper to upload a file directly to S3 via presigned URL
-const uploadToS3 = async (file: File) => {
+export const uploadToS3 = async (file: File) => {
 	// 1. Get presigned URL
 	const { data } = await APIAxios.get(`/media/generate-upload-url`, {
 		params: {


### PR DESCRIPTION
Pairs with the backend PR that accepts a replacement audio file. Before this there was no way for an artist to fix a release rejected over its format — the catalog only allowed metadata edits and cover-art swaps, so the audio file itself could never be replaced. The only route out was asking an admin to delete the release and starting over.

## Changes

- **"Replace audio file" control** in the track edit sheet, showing the current filename and accepting **WAV/FLAC only**, with the reason MP3 is refused stated inline rather than after a failed upload.
- **Hidden once the release is with stores** (`delivered` / `delivering`), matching the API, which rejects a swap at that point.
- The update helper uploads the new file to S3 via the existing presigned-URL flow and sends it as `mediaUrl`; the API re-validates the format and re-checks whether the release and its album can now be delivered.
- Success toast says the release was sent back for review when the file changed, since that's what the API does.
- `uploadToS3` is now exported from the upload flow instead of being duplicated.

## Testing

`tsc --noEmit` clean. Not click-tested — needs the backend PR deployed to exercise end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)