### PR TITLE
Pick who gets the report email instead of mailing everyone

### DIFF
--- a/src/app/admin/(main)/catalogue/api/matchArtistReports.ts
+++ b/src/app/admin/(main)/catalogue/api/matchArtistReports.ts
@@ -1,6 +1,6 @@
 // src/api/matchArtistReports.ts
 import APIAxios from '@/utils/axios';
-import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import { useMutation, UseMutationResult, useQuery } from '@tanstack/react-query';
 import { ReportItem } from '@/lib/types';
 
 // Define the request payload interface
@@ -85,6 +85,62 @@ export const releaseReports = async (params: ReleaseReportsParams): Promise<Rele
 export const useReleaseReports = (): UseMutationResult<ReleaseReportsResponse, Error, ReleaseReportsParams, unknown> => {
 	return useMutation({
 		mutationFn: releaseReports
+	});
+};
+
+export interface ReportEmailRecipient {
+	artistId: string;
+	artistName: string | null;
+	email: string | null;
+	status: string | null;
+	// False when the artist can't be mailed at all (inactive, or no address).
+	emailable: boolean;
+	reason: string | null;
+}
+
+export interface ReportEmailRecipientsResponse {
+	reportId: string;
+	activityPeriod: string | null;
+	released: boolean;
+	recipients: ReportEmailRecipient[];
+}
+
+// Everyone holding a share on the report, for the notify-artists picker.
+export const getReportEmailRecipients = async (reportId: string): Promise<ReportEmailRecipientsResponse> => {
+	const response = await APIAxios.get(`/admin/report/${encodeURIComponent(reportId)}/email-recipients`);
+	return response.data;
+};
+
+export const useGetReportEmailRecipients = (reportId: string | null) => {
+	return useQuery({
+		queryKey: ['reportEmailRecipients', reportId],
+		queryFn: () => getReportEmailRecipients(reportId as string),
+		enabled: !!reportId
+	});
+};
+
+export interface SendReportEmailsParams {
+	reportId: string;
+	// Omit to mail every artist on the report.
+	artistIds?: string[];
+}
+
+export interface SendReportEmailsResponse {
+	requested: number;
+	sent: number;
+	skipped: { artistId: string; artistName: string | null; reason: string }[];
+}
+
+// Emails an already-released report to a chosen set of artists. Separate from
+// releasing, which moves the money.
+export const sendReportEmails = async (params: SendReportEmailsParams): Promise<SendReportEmailsResponse> => {
+	const response = await APIAxios.post('/admin/send_report_emails', params, {});
+	return response.data;
+};
+
+export const useSendReportEmails = (): UseMutationResult<SendReportEmailsResponse, Error, SendReportEmailsParams, unknown> => {
+	return useMutation({
+		mutationFn: sendReportEmails
 	});
 };
 

--- a/src/app/admin/(main)/sales-history/[activityPeriod]/page.tsx
+++ b/src/app/admin/(main)/sales-history/[activityPeriod]/page.tsx
@@ -13,8 +13,9 @@ import { Button } from '@/components/ui/button';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { LoadingBox } from '@/components/ui/LoadingBox';
 import DeletionProgressModal from '@/components/ui/delete-records-modal';
+import NotifyArtistsModal from '../misc/components/NotifyArtistsModal';
 import { formatCurrency } from '@/utils/currency';
-import { Calendar, BarChart3, FileText, TrendingUp, Music, Users, Eye, AlertTriangle, Loader2, Trash2, Send } from 'lucide-react';
+import { Calendar, BarChart3, FileText, TrendingUp, Music, Users, Eye, AlertTriangle, Loader2, Trash2, Send, Mail } from 'lucide-react';
 import { toast } from 'sonner';
 import { NairaIcon } from '@/components/ui/naira-icon';
 
@@ -34,6 +35,7 @@ const ActivityPeriodContent: React.FC = () => {
 	const { mutate: deleteRecords } = useDeleteSalesHistory();
 	const { mutate: releaseReport } = useReleaseReports();
 	const [releasingId, setReleasingId] = useState<string | null>(null);
+	const [notifyReportId, setNotifyReportId] = useState<string | null>(null);
 
 	const reports = useMemo(() => periodData?.data || [], [periodData]);
 	const summary = periodData?.summary || { totalNetRevenue: 0, totalGrossRevenue: 0, totalTracks: 0, totalArtists: 0 };
@@ -104,12 +106,14 @@ const ActivityPeriodContent: React.FC = () => {
 		const confirmed = window.confirm('Release this report to artists? This credits their wallets and makes it visible on their dashboards. It moves money and cannot be undone.');
 		if (!confirmed) return;
 		setReleasingId(reportId);
+		// Releasing no longer emails anyone: notifying is the separate "Send
+		// email" action, where the admin picks who hears about it.
 		releaseReport(
-			{ reportId, sendEmails: true },
+			{ reportId, sendEmails: false },
 			{
 				onSuccess: data => {
 					setReleasingId(null);
-					toast.success(`Released to ${data.artistsCredited} artist(s), ${data.emailsSent} notified.`);
+					toast.success(`Released to ${data.artistsCredited} artist(s). Use "Send email" to notify them.`);
 					refetch();
 				},
 				onError: (err: unknown) => {
@@ -192,7 +196,13 @@ const ActivityPeriodContent: React.FC = () => {
 					return (
 						<div className="flex items-center justify-end gap-1">
 							{row.original.released ? (
-								<Badge variant="success">Released</Badge>
+								<>
+									<Badge variant="success">Released</Badge>
+									<Button variant="ghost" size="sm" onClick={() => setNotifyReportId(reportId)}>
+										<Mail className="w-4 h-4 mr-1" />
+										Send email
+									</Button>
+								</>
 							) : (
 								<Button variant="outline" size="sm" onClick={() => handleReleaseReport(reportId)} disabled={isReleasing || releasingId !== null}>
 									{isReleasing ? (
@@ -428,6 +438,7 @@ const ActivityPeriodContent: React.FC = () => {
 
 			{/* Modal for deletion progress */}
 			<DeletionProgressModal isOpen={isDeletionModalOpen} onClose={handleCloseDeletionModal} reportIdsToDelete={selectedReportIds} />
+			<NotifyArtistsModal reportId={notifyReportId} isOpen={!!notifyReportId} onClose={() => setNotifyReportId(null)} />
 		</div>
 	);
 };

--- a/src/app/admin/(main)/sales-history/misc/components/NotifyArtistsModal.tsx
+++ b/src/app/admin/(main)/sales-history/misc/components/NotifyArtistsModal.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { useGetReportEmailRecipients, useSendReportEmails } from '@/app/admin/(main)/catalogue/api/matchArtistReports';
+
+interface NotifyArtistsModalProps {
+	reportId: string | null;
+	isOpen: boolean;
+	onClose: () => void;
+}
+
+/**
+ * Picks which artists on a report get the "report ready" email. Releasing used
+ * to mail everyone as a side effect of moving the money; this is the separate,
+ * deliberate step.
+ */
+const NotifyArtistsModal: React.FC<NotifyArtistsModalProps> = ({ reportId, isOpen, onClose }) => {
+	const { data, isLoading, isError } = useGetReportEmailRecipients(isOpen ? reportId : null);
+	const { mutate: sendEmails, isPending } = useSendReportEmails();
+	const [selectedIds, setSelectedIds] = useState<string[]>([]);
+	const [search, setSearch] = useState('');
+
+	const recipients = useMemo(() => data?.recipients ?? [], [data]);
+	const emailable = useMemo(() => recipients.filter(r => r.emailable), [recipients]);
+	const skipped = useMemo(() => recipients.filter(r => !r.emailable), [recipients]);
+
+	// Default to everyone who can actually receive it — the common case is
+	// notifying the whole report, and the admin narrows from there.
+	useEffect(() => {
+		setSelectedIds(emailable.map(r => r.artistId));
+	}, [emailable]);
+
+	const visible = useMemo(() => {
+		const term = search.trim().toLowerCase();
+		if (!term) return emailable;
+		return emailable.filter(r => (r.artistName || '').toLowerCase().includes(term) || (r.email || '').toLowerCase().includes(term));
+	}, [emailable, search]);
+
+	const allVisibleSelected = visible.length > 0 && visible.every(r => selectedIds.includes(r.artistId));
+
+	const toggleAllVisible = () => {
+		const visibleIds = visible.map(r => r.artistId);
+		setSelectedIds(prev => (allVisibleSelected ? prev.filter(id => !visibleIds.includes(id)) : Array.from(new Set([...prev, ...visibleIds]))));
+	};
+
+	const toggleOne = (artistId: string) => {
+		setSelectedIds(prev => (prev.includes(artistId) ? prev.filter(id => id !== artistId) : [...prev, artistId]));
+	};
+
+	const handleSend = () => {
+		if (!reportId || selectedIds.length === 0) return;
+		sendEmails(
+			{ reportId, artistIds: selectedIds },
+			{
+				onSuccess: result => {
+					toast.success(`Emailed ${result.sent} of ${result.requested} selected artist(s).`);
+					onClose();
+				},
+				onError: (err: unknown) => {
+					const axiosErr = err as { response?: { data?: { message?: string } } };
+					toast.error(axiosErr?.response?.data?.message || 'Failed to send report emails.');
+				}
+			}
+		);
+	};
+
+	return (
+		<Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
+			<DialogContent className="max-w-lg">
+				<DialogHeader>
+					<DialogTitle>Send report email</DialogTitle>
+				</DialogHeader>
+
+				{isLoading && (
+					<div className="flex items-center justify-center py-10 text-white/60">
+						<Loader2 className="h-5 w-5 animate-spin mr-2" /> Loading artists…
+					</div>
+				)}
+
+				{isError && <p className="py-6 text-sm text-red-400">Couldn&apos;t load the artists on this report.</p>}
+
+				{!isLoading && !isError && data && (
+					<div className="space-y-4">
+						{!data.released && <p className="text-xs text-amber-400">This report hasn&apos;t been released yet. Release it first — the email asks artists to log in and view figures they can&apos;t see until then.</p>}
+
+						<input type="text" value={search} onChange={e => setSearch(e.target.value)} placeholder="Search artists…" className="w-full rounded-md bg-transparent border border-border px-3 py-2 text-sm" />
+
+						<div className="flex items-center justify-between text-sm">
+							<label className="flex items-center gap-2 cursor-pointer">
+								<Checkbox checked={allVisibleSelected} onCheckedChange={toggleAllVisible} />
+								<span>Select all {search ? 'shown' : ''}</span>
+							</label>
+							<span className="text-white/50">{selectedIds.length} selected</span>
+						</div>
+
+						<div className="max-h-64 overflow-y-auto rounded-md border border-border divide-y divide-border">
+							{visible.map(recipient => (
+								<label key={recipient.artistId} className="flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-white/5">
+									<Checkbox checked={selectedIds.includes(recipient.artistId)} onCheckedChange={() => toggleOne(recipient.artistId)} />
+									<span className="flex flex-col">
+										<span className="text-sm">{recipient.artistName || 'Unnamed artist'}</span>
+										<span className="text-xs text-white/40">{recipient.email}</span>
+									</span>
+								</label>
+							))}
+							{visible.length === 0 && <p className="px-3 py-4 text-sm text-white/50">No artists match that search.</p>}
+						</div>
+
+						{skipped.length > 0 && (
+							<details className="text-xs text-white/50">
+								<summary className="cursor-pointer">{skipped.length} artist(s) can&apos;t be emailed</summary>
+								<ul className="mt-2 space-y-1 pl-4 list-disc">
+									{skipped.map(recipient => (
+										<li key={recipient.artistId}>
+											{recipient.artistName || recipient.artistId} — {recipient.reason}
+										</li>
+									))}
+								</ul>
+							</details>
+						)}
+					</div>
+				)}
+
+				<div className="flex justify-end gap-3 pt-2">
+					<Button variant="outline" className="rounded-full" onClick={onClose} disabled={isPending}>
+						Cancel
+					</Button>
+					<Button className="rounded-full" onClick={handleSend} disabled={isPending || selectedIds.length === 0 || !data?.released}>
+						{isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : `Send to ${selectedIds.length}`}
+					</Button>
+				</div>
+			</DialogContent>
+		</Dialog>
+	);
+};
+
+export default NotifyArtistsModal;


### PR DESCRIPTION
Closes the last piece of the release/notify split. The backend endpoints have been merged since My-AirPlay/backend#129; this is the UI they were waiting on.

## The problem

`sales-history/[activityPeriod]/page.tsx` released with `sendEmails: true` and **no recipient list**, so it mailed every credited artist as a side effect of moving the money — no way to choose who, and no way to email again afterwards. The other two release paths (`sales/page.tsx`, `sales-history/process/[reportId]`) already passed a chosen list; this one was the blaster.

## Changes

- **Release posts `sendEmails: false`.** Money and email are now separate actions, and the success toast points at the new one.
- **"Send email" action** on released reports, opening a recipient picker.
- **`NotifyArtistsModal`** lists everyone holding a share on the report — all selected by default, since notifying the whole report is the common case — with search and select-all-shown. Artists who *can't* be emailed (inactive, or no address on file) are listed separately with the reason, rather than silently dropped, so the count adding up is explicable.
- **Sending is blocked while a report is unreleased**, matching the API: the email tells artists to log in and view figures that stay hidden until release.

New API helpers wrap `GET /admin/report/:reportId/email-recipients` and `POST /admin/send_report_emails`.

## Testing

`tsc --noEmit` and `npm run build` both clean. Not click-tested — sending writes real email, so I left that to you.

Note: Vercel's check has been failing on `main` since well before these changes (at least 4 commits back, including ones untouched by this work). A clean local `next build` passes, so it's a deploy/config issue rather than code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)